### PR TITLE
Update to mobx-state-tree 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "jest": "^19.0.0",
     "mobx": "^4.3.1",
-    "mobx-state-tree": "^2.2.0",
+    "mobx-state-tree": "^3.0.0",
     "react": "^15.0.0",
     "react-router": "^4.0.0",
     "rimraf": "^2.5.4",

--- a/src/store.js
+++ b/src/store.js
@@ -2,7 +2,7 @@ import { types } from 'mobx-state-tree';
 
 export const RouterModel = types
   .model('RouterModel', {
-    location: types.optional(types.frozen),
+    location: types.optional(types.frozen()),
     action: types.optional(types.string, '')
   })
   .actions(routerModel => {


### PR DESCRIPTION
`mobx-state-tree` 3.0.0 was released today. Unfortunately, one of the breaking changes was `types.frozen` moving to `types.frozen()` - which makes this lib break.

This PR updates to 3.0.0 and adjusts to make the lib work again.

I'm guessing this should be a major version change, as well? Perhaps `mst-react-router@3.0.0`, to synchronize with `mobx-state-tree`'s major version?